### PR TITLE
Use 32-bit marker for timestamp/measure modules

### DIFF
--- a/core/modules/measure.h
+++ b/core/modules/measure.h
@@ -7,13 +7,12 @@
 
 class Measure final : public Module {
  public:
-  static const Commands cmds;
-
   Measure()
       : Module(),
         hist_(Histogram<uint64_t>(kBuckets, kBucketWidth)),
-        start_time_(),
-        warmup_(),
+        start_ns_(),
+        warmup_ns_(),
+        offset_(),
         pkt_cnt_(),
         bytes_cnt_(),
         total_latency_() {}
@@ -24,19 +23,21 @@ class Measure final : public Module {
 
   pb_cmd_response_t CommandGetSummary(const bess::pb::EmptyArg &arg);
 
+  static const Commands cmds;
+
  private:
+  static const uint64_t kBucketWidth = 100;  // Measure in 100 ns units
+  static const uint64_t kBuckets = 1000000;
+
   Histogram<uint64_t> hist_;
 
-  uint64_t start_time_;
-  int warmup_;     // in seconds
-  size_t offset_;  // in bytes
+  uint64_t start_ns_;
+  uint64_t warmup_ns_;  // no measurement for this warmup period
+  size_t offset_;       // in bytes
 
   uint64_t pkt_cnt_;
   uint64_t bytes_cnt_;
   uint64_t total_latency_;
-
-  static const uint64_t kBucketWidth = 100;  // Measure in 100 ns units
-  static const uint64_t kBuckets = 1000000;
 };
 
 #endif  // BESS_MODULES_MEASURE_H_

--- a/core/modules/timestamp.h
+++ b/core/modules/timestamp.h
@@ -6,6 +6,9 @@
 
 class Timestamp final : public Module {
  public:
+  using MarkerType = uint32_t;
+  static const MarkerType kMarker = 0x54C5BE55;
+
   pb_error_t Init(const bess::pb::TimestampArg &arg);
 
   void ProcessBatch(bess::PacketBatch *batch) override;

--- a/protobuf/module_msg.proto
+++ b/protobuf/module_msg.proto
@@ -226,7 +226,7 @@ message MACSwapArg {
 }
 
 message MeasureArg {
-  int64 warmup = 1;
+  uint32 warmup = 1;
   uint64 offset = 2;
 }
 


### PR DESCRIPTION
and some microoptimization and style revision...

With Source() -> Timestamp() -> Measure(), actually 4-byte marker has performance advantage over 2-byte one (38Mpps -> 43Mpps on my machine). Perhaps the performance hit you saw might have been from pkt->append(), which shouldn't be an issue with UDP offset.

In x86, use of 1/2 byte data is only equivalent to or even worse than 4/8, except its cache impact. When registers switch between 1/2 and 4/8 byte words, the CPU pipeline will suffer pipeline stalls: http://stackoverflow.com/questions/11177137/why-do-most-x64-instructions-zero-the-upper-part-of-a-32-bit-register

The real cycle hogger was 64-bit integer division in the histogram code (more than half of the CPU cycles out of the whole pipeline). We can use some precomputation tricks (e.g., http://dpdk.org/doc/api/rte__approx_8h.html) later.